### PR TITLE
RFR - Artists index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.2.2'
 
+gem 'active_model_serializers', '0.8.3'
 gem 'airbrake'
 gem 'autoprefixer-rails'
 gem 'bourbon', '~> 4.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :test do
   gem 'capybara-webkit', '>= 1.2.0'
   gem 'database_cleaner'
   gem 'formulaic'
+  gem 'json-schema'
   gem 'launchy'
   gem 'shoulda-matchers', require: false
   gem 'simplecov', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,58 +1,59 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-ruby "2.2.2"
+ruby '2.2.2'
 
-gem "airbrake"
-gem "autoprefixer-rails"
-gem "bourbon", "~> 4.2.0"
-gem "coffee-rails", "~> 4.1.0"
-gem "delayed_job_active_record"
-gem "email_validator"
-gem "flutie"
-gem "high_voltage"
-gem "i18n-tasks"
-gem "jquery-rails"
-gem "neat", "~> 1.7.0"
-gem "newrelic_rpm", ">= 3.9.8"
-gem "normalize-rails", "~> 3.0.0"
-gem "pg"
-gem "rack-canonical-host"
-gem "rails", "4.2.1"
-gem "recipient_interceptor"
-gem "refills"
-gem "sass-rails", "~> 5.0"
-gem "simple_form"
-gem "title"
-gem "uglifier"
-gem "unicorn"
+gem 'airbrake'
+gem 'autoprefixer-rails'
+gem 'bourbon', '~> 4.2.0'
+gem 'coffee-rails', '~> 4.1.0'
+gem 'delayed_job_active_record'
+gem 'email_validator'
+gem 'flutie'
+gem 'high_voltage'
+gem 'i18n-tasks'
+gem 'jquery-rails'
+gem 'neat', '~> 1.7.0'
+gem 'newrelic_rpm', '>= 3.9.8'
+gem 'normalize-rails', '~> 3.0.0'
+gem 'pg'
+gem 'rack-canonical-host'
+gem 'rails', '4.2.1'
+gem 'recipient_interceptor'
+gem 'refills'
+gem 'sass-rails', '~> 5.0'
+gem 'simple_form'
+gem 'title'
+gem 'uglifier'
+gem 'unicorn'
+gem 'versionist'
 
 group :development do
-  gem "spring"
-  gem "spring-commands-rspec"
-  gem "web-console"
+  gem 'spring'
+  gem 'spring-commands-rspec'
+  gem 'web-console'
 end
 
 group :development, :test do
-  gem "awesome_print"
-  gem "bundler-audit", require: false
-  gem "byebug"
-  gem "dotenv-rails"
-  gem "factory_girl_rails"
-  gem "pry-rails"
-  gem "rspec-rails", "~> 3.1.0"
+  gem 'awesome_print'
+  gem 'bundler-audit', require: false
+  gem 'byebug'
+  gem 'dotenv-rails'
+  gem 'factory_girl_rails'
+  gem 'pry-rails'
+  gem 'rspec-rails', '~> 3.1.0'
 end
 
 group :test do
-  gem "capybara-webkit", ">= 1.2.0"
-  gem "database_cleaner"
-  gem "formulaic"
-  gem "launchy"
-  gem "shoulda-matchers", require: false
-  gem "simplecov", require: false
-  gem "timecop"
-  gem "webmock"
+  gem 'capybara-webkit', '>= 1.2.0'
+  gem 'database_cleaner'
+  gem 'formulaic'
+  gem 'launchy'
+  gem 'shoulda-matchers', require: false
+  gem 'simplecov', require: false
+  gem 'timecop'
+  gem 'webmock'
 end
 
 group :staging, :production do
-  gem "rack-timeout"
+  gem 'rack-timeout'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    json-schema (2.5.1)
+      addressable (~> 2.3.7)
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -289,6 +291,7 @@ DEPENDENCIES
   high_voltage
   i18n-tasks
   jquery-rails
+  json-schema
   launchy
   neat (~> 1.7.0)
   newrelic_rpm (>= 3.9.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    active_model_serializers (0.8.3)
+      activemodel (>= 3.0)
     activejob (4.2.1)
       activesupport (= 4.2.1)
       globalid (>= 0.3.0)
@@ -273,6 +275,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (= 0.8.3)
   airbrake
   autoprefixer-rails
   awesome_print

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,10 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    versionist (1.4.1)
+      activesupport (>= 3)
+      railties (>= 3)
+      yard (~> 0.7)
     web-console (2.1.2)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -261,6 +265,7 @@ GEM
       crack (>= 0.3.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -306,5 +311,6 @@ DEPENDENCIES
   title
   uglifier
   unicorn
+  versionist
   web-console
   webmock

--- a/app/controllers/v1/artists_controller.rb
+++ b/app/controllers/v1/artists_controller.rb
@@ -1,0 +1,7 @@
+class V1::ArtistsController < ApplicationController
+  def index
+    artists = Artist.all
+
+    render json: artists
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,0 +1,4 @@
+class Artist < ActiveRecord::Base
+  validates :name, presence: true
+  validates :spotify_uri, presence: true, uniqueness: true
+end

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -1,0 +1,3 @@
+class ArtistSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description, :spotify_uri
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,10 @@
 Rails.application.routes.draw do
+  api_version(module: 'V1',
+              header: {
+                name: 'Accept',
+                value: 'application/vnd.spotify-apprentice-app.com; version=1'
+              },
+              defaults: { format: :json }) do
+    resources :artists, only: :index
+  end
 end

--- a/db/migrate/20150609174024_create_artists.rb
+++ b/db/migrate/20150609174024_create_artists.rb
@@ -1,0 +1,15 @@
+class CreateArtists < ActiveRecord::Migration
+  def change
+    enable_extension 'uuid-ossp'
+
+    create_table :artists, id: :uuid do |t|
+      t.timestamps null: false
+
+      t.string :name
+      t.text :description
+      t.string :spotify_uri
+    end
+
+    add_index :artists, :spotify_uri, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150609172319) do
+ActiveRecord::Schema.define(version: 20150609174024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
+
+  create_table "artists", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.string   "name"
+    t.text     "description"
+    t.string   "spotify_uri"
+  end
+
+  add_index "artists", ["spotify_uri"], name: "index_artists_on_spotify_uri", unique: true, using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false

--- a/spec/factories/artists.rb
+++ b/spec/factories/artists.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :artist do
+    name 'Michael Jackson'
+    description 'The king of pop'
+    spotify_uri { SecureRandom.hex(10) }
+  end
+end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe Artist do
+  describe 'validations' do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :spotify_uri }
+    it { should validate_uniqueness_of :spotify_uri }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ end
 
 RSpec.configure do |config|
   config.include Features, type: :feature
+  config.include Helpers::Requests, type: :request
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -6,7 +6,7 @@ describe 'artists endpoints' do
       artists = create_list(:artist, 3)
 
       get(artists_url, {}, accept_headers)
-
+binding.pry
       expect(response).to have_http_status :ok
       expect(response).to match_response_schema :artists
     end

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'artists endpoints' do
+  describe 'GET /artists' do
+    it 'returns JSON for all artists' do
+      artists = create_list(:artist, 3)
+
+      get(artists_url, {}, accept_headers)
+
+      expect(response).to have_http_status :ok
+      expect(response).to match_response_schema :artists
+    end
+  end
+end

--- a/spec/support/api/schemas/artists.json
+++ b/spec/support/api/schemas/artists.json
@@ -1,45 +1,42 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "http://spotify-apprentice-app.com",
-  "type": "array",
-  "items": [
-    {
-      "id": "http://spotify-apprentice-app.com/0",
-      "type": "object",
-      "properties": {
-        "id": {
-          "id": "http://spotify-apprentice-app.com/0/id",
-          "type": "string"
+  "type": "object",
+  "properties": {
+    "artists": {
+      "id": "http://spotify-apprentice-app.com/artists",
+      "type": "array",
+      "items": {
+        "id": "http://spotify-apprentice-app.com/artists/0",
+        "type": "object",
+        "properties": {
+          "id": {
+            "id": "http://spotify-apprentice-app.com/artists/0/id",
+            "type": "string"
+          },
+          "name": {
+            "id": "http://spotify-apprentice-app.com/artists/0/name",
+            "type": "string"
+          },
+          "description": {
+            "id": "http://spotify-apprentice-app.com/artists/0/description",
+            "type": "string"
+          },
+          "spotify_uri": {
+            "id": "http://spotify-apprentice-app.com/artists/0/spotify_uri",
+            "type": "string"
+          }
         },
-        "created_at": {
-          "id": "http://spotify-apprentice-app.com/0/created_at",
-          "type": "string"
-        },
-        "updated_at": {
-          "id": "http://spotify-apprentice-app.com/0/updated_at",
-          "type": "string"
-        },
-        "name": {
-          "id": "http://spotify-apprentice-app.com/0/name",
-          "type": "string"
-        },
-        "description": {
-          "id": "http://spotify-apprentice-app.com/0/description",
-          "type": "string"
-        },
-        "spotify_uri": {
-          "id": "http://spotify-apprentice-app.com/0/spotify_uri",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "created_at",
-        "updated_at",
-        "name",
-        "description",
-        "spotify_uri"
-      ]
+        "required": [
+          "id",
+          "name",
+          "description",
+          "spotify_uri"
+        ]
+      }
     }
+  },
+  "required": [
+    "artists"
   ]
 }

--- a/spec/support/api/schemas/artists.json
+++ b/spec/support/api/schemas/artists.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://spotify-apprentice-app.com",
+  "type": "array",
+  "items": [
+    {
+      "id": "http://spotify-apprentice-app.com/0",
+      "type": "object",
+      "properties": {
+        "id": {
+          "id": "http://spotify-apprentice-app.com/0/id",
+          "type": "string"
+        },
+        "created_at": {
+          "id": "http://spotify-apprentice-app.com/0/created_at",
+          "type": "string"
+        },
+        "updated_at": {
+          "id": "http://spotify-apprentice-app.com/0/updated_at",
+          "type": "string"
+        },
+        "name": {
+          "id": "http://spotify-apprentice-app.com/0/name",
+          "type": "string"
+        },
+        "description": {
+          "id": "http://spotify-apprentice-app.com/0/description",
+          "type": "string"
+        },
+        "spotify_uri": {
+          "id": "http://spotify-apprentice-app.com/0/spotify_uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "created_at",
+        "updated_at",
+        "name",
+        "description",
+        "spotify_uri"
+      ]
+    }
+  ]
+}

--- a/spec/support/helpers/requests.rb
+++ b/spec/support/helpers/requests.rb
@@ -1,0 +1,24 @@
+module Helpers
+  module Requests
+    def json
+      @json ||= parse_json(response.body)
+    end
+
+    def errors
+      json['errors'].to_s if json['errors']
+    end
+
+    def api_version
+      1
+    end
+
+    def accept_header
+      "application/vnd.spotify-apprentice-app.com+json; version=#{api_version}"
+    end
+
+    def accept_headers
+      { 'Accept' => accept_header,
+        'Content-Type' => 'application/json' }
+    end
+  end
+end

--- a/spec/support/helpers/requests.rb
+++ b/spec/support/helpers/requests.rb
@@ -1,7 +1,7 @@
 module Helpers
   module Requests
     def json
-      @json ||= parse_json(response.body)
+      @json ||= JSON.parse(response.body)
     end
 
     def errors
@@ -13,7 +13,7 @@ module Helpers
     end
 
     def accept_header
-      "application/vnd.spotify-apprentice-app.com+json; version=#{api_version}"
+      "application/vnd.spotify-apprentice-app.com; version=#{api_version}"
     end
 
     def accept_headers

--- a/spec/support/matchers/api_schema_matcher.rb
+++ b/spec/support/matchers/api_schema_matcher.rb
@@ -1,0 +1,7 @@
+RSpec::Matchers.define :match_response_schema do |schema|
+  match do |response|
+    schema_directory = "#{Dir.pwd}/spec/support/api/schemas"
+    schema_path = "#{schema_directory}/#{schema}.json"
+    JSON::Validator.validate!(schema_path, response.body, strict: true)
+  end
+end


### PR DESCRIPTION
This PR adds a `GET /artists` endpoint that provides JSON for all artists.  A version number can be passed in the accept header.

**Sample Request**

```
GET /artists HTTP/1.1
Accept: application/vnd.spotifity-apprentice-app.com+json; version=1
```

**Sample Response**

```
HTTP/1.1 200 OK 

{
  "artists": [
    {
      "id": "f4859e65-942b-4320-9c8f-55d0173d8767",
      "name": "Michael Jackson",
      "description": "The king of pop",
      "spotify_uri": "5af1515c36eeee3c5414"
    }
  ]
}
```
