### PR TITLE
RFR - Add an artist

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,3 @@
+class ApiController < ApplicationController
+  protect_from_forgery with: :null_session
+end

--- a/app/controllers/v1/artists_controller.rb
+++ b/app/controllers/v1/artists_controller.rb
@@ -1,7 +1,21 @@
 class V1::ArtistsController < ApplicationController
+  def create
+    artist = Artist.new(artist_params)
+
+    artist.save
+    
+    render json: artist, status: :created
+  end
+
   def index
     artists = Artist.all
 
     render json: artists
+  end
+
+  private
+
+  def artist_params
+    params.require(:artist).permit(:name, :description, :spotify_uri)
   end
 end

--- a/app/controllers/v1/artists_controller.rb
+++ b/app/controllers/v1/artists_controller.rb
@@ -1,4 +1,4 @@
-class V1::ArtistsController < ApplicationController
+class V1::ArtistsController < ApiController
   def create
     artist = Artist.new(artist_params)
 

--- a/app/controllers/v1/artists_controller.rb
+++ b/app/controllers/v1/artists_controller.rb
@@ -2,9 +2,12 @@ class V1::ArtistsController < ApplicationController
   def create
     artist = Artist.new(artist_params)
 
-    artist.save
-    
-    render json: artist, status: :created
+    if artist.save
+      render json: artist, status: :created
+    else
+      render json: { errors: artist.errors.full_messages },
+             status: :unprocessable_entity
+    end
   end
 
   def index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
                 value: 'application/vnd.spotify-apprentice-app.com; version=1'
               },
               defaults: { format: :json }) do
-    resources :artists, only: :index
+    resources :artists, only: [:index, :create]
   end
 end

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -1,6 +1,49 @@
 require 'rails_helper'
 
 describe 'artists endpoints' do
+  describe 'POST /artists' do
+    context 'with valid params' do
+      it 'returns a 201 - Created response' do
+        artist_attrs = attributes_for(:artist)
+
+        post(artists_url, { artist: artist_attrs }.to_json, accept_headers)
+
+        expect(response).to have_http_status :created
+      end
+
+      it 'creates a new artist' do
+        artist_attrs = attributes_for(:artist)
+
+        expect {
+          post(artists_url, { artist: artist_attrs }.to_json, accept_headers)
+        }.to change { Artist.count }.by 1
+      end
+
+      it 'returns JSON for the artist' do
+        artist_attrs = attributes_for(:artist)
+
+        post(artists_url, { artist: artist_attrs }.to_json, accept_headers)
+
+        expect(response).to match_response_schema :artist
+      end
+    end
+
+    context 'missing a name' do
+      it 'returns a 422 - Unprocessable Entity response'
+      it 'returns JSON for errors'
+    end
+
+    context 'missing spotify_uri' do
+      it 'returns a 422 - Unprocessable Entity response'
+      it 'returns JSON for errors'
+    end
+
+    context 'when spotify_uri already taken' do
+      it 'returns a 422 - Unprocessable Entity response'
+      it 'returns JSON for errors'
+    end
+  end
+
   describe 'GET /artists' do
     it 'returns JSON for all artists' do
       artists = create_list(:artist, 3)

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -4,24 +4,18 @@ describe 'artists endpoints' do
   describe 'POST /artists' do
     context 'with valid params' do
       it 'returns a 201 - Created response' do
-        artist_attrs = attributes_for(:artist)
-
         post(artists_url, { artist: artist_attrs }.to_json, accept_headers)
 
         expect(response).to have_http_status :created
       end
 
       it 'creates a new artist' do
-        artist_attrs = attributes_for(:artist)
-
         expect {
           post(artists_url, { artist: artist_attrs }.to_json, accept_headers)
         }.to change { Artist.count }.by 1
       end
 
       it 'returns JSON for the artist' do
-        artist_attrs = attributes_for(:artist)
-
         post(artists_url, { artist: artist_attrs }.to_json, accept_headers)
 
         expect(response).to match_response_schema :artist
@@ -54,4 +48,8 @@ describe 'artists endpoints' do
       expect(response).to match_response_schema :artists
     end
   end
+end
+
+def artist_attrs
+  @artist_attrs ||= attributes_for(:artist)
 end

--- a/spec/requests/v1/artists_request_spec.rb
+++ b/spec/requests/v1/artists_request_spec.rb
@@ -23,8 +23,21 @@ describe 'artists endpoints' do
     end
 
     context 'missing a name' do
-      it 'returns a 422 - Unprocessable Entity response'
-      it 'returns JSON for errors'
+      it 'returns a 422 - Unprocessable Entity response' do
+        invalid_attrs = artist_attrs.merge(name: '')
+
+        post(artists_url, { artist: invalid_attrs }.to_json, accept_headers)
+
+        expect(response).to have_http_status :unprocessable_entity
+      end
+
+      it 'returns JSON for errors' do
+        invalid_attrs = artist_attrs.merge(name: '')
+
+        post(artists_url, { artist: invalid_attrs }.to_json, accept_headers)
+
+        expect(errors).to include "can't be blank"
+      end
     end
 
     context 'missing spotify_uri' do

--- a/spec/support/api/schemas/artist.json
+++ b/spec/support/api/schemas/artist.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://spotify-apprentice-app.com",
+  "type": "object",
+  "properties": {
+    "artist": {
+      "id": "http://spotify-apprentice-app.com/artist",
+      "type": "object",
+      "properties": {
+        "id": {
+          "id": "http://spotify-apprentice-app.com/artist/id",
+          "type": "string"
+        },
+        "name": {
+          "id": "http://spotify-apprentice-app.com/artist/name",
+          "type": "string"
+        },
+        "description": {
+          "id": "http://spotify-apprentice-app.com/artist/description",
+          "type": ["string", "null"]
+        },
+        "spotify_uri": {
+          "id": "http://spotify-apprentice-app.com/artist/spotify_uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "spotify_uri"
+      ]
+    }
+  },
+  "required": [
+    "artist"
+  ]
+}


### PR DESCRIPTION
Adds a `POST /artists` endpoint for creating an artist.

**The Rules**
- Must provide a `name` and `spotify_uri`
- `spotify_uri` must be unique
- Otherwise returns 422 Unprocessable Entity response

**Sample Request**

```
POST /artists HTTP/1.1
Accept: application/vnd.spotify-apprentice-app.com; version=1
Content-Type: application/json

{
  "artist": {
    "name": "U2",
    "description": "Kind of annoying",
    "spotify_uri": "7f7bda08fb9ea99f"
  }
}
```

**Sample Response**

```
HTTP/1.1 201 Created

{
  "artist": {
    "id": "29d30239-08e2-478a-a4fd-9d69e0eb0e33",
    "name": "U2",
    "description": "Kind of annoying",
    "spotify_uri": "7f7bda08fb9ea99f"
  }
}
```

**Sample Error Response**

```
HTTP/1.1 422 Unprocessable Entity

{
  "errors": [
    "Spotify uri can't be blank"
  ]
}
```

TODO: 
- [ ] Flesh out pending tests
